### PR TITLE
Require OAuth credentials for Google Drive connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ available) or a local folder for PDFs.
 - **Prompt-Driven Conversion** – Submit a reusable conversion prompt that asks
   the LLM to produce publication-quality Markdown from each PDF.
 - **Result Management** – Store the generated Markdown documents in a local
-  destination that can be synchronized with tools such as Obsidian.
+  destination or commit the results to a Git repository that can be
+  synchronized with tools such as Obsidian.
 
 ## Planned Components
 
@@ -32,8 +33,9 @@ The core modules that make up the project include:
 4. **LLM Client** – A pluggable interface with an initial implementation that
    uses [`pypdf`](https://pypi.org/project/pypdf/) to extract text locally and
    emit Markdown. This can be swapped with a real LLM integration.
-5. **Markdown Output Handler** – Writes conversion results to the destination
-   folder and prepares a foundation for future asset management.
+5. **Markdown Output Handlers** – Write conversion results either to the local
+   filesystem or directly into a Git repository (committing changes and
+   optionally pushing to a remote).
 
 ## Getting Started
 
@@ -49,13 +51,33 @@ pip install .[dev]
 
 You will also need to supply:
 
-- Google Drive credentials with permission to read the monitored folder (for
-  the Google Drive connector).
+- Google Drive OAuth credentials for the end user whose My Drive should be
+  monitored. Provide the downloaded client secrets file via
+  `google_drive.oauth_client_secrets_file` and choose a writable path for
+  `google_drive.oauth_token_file` so the connector can cache the refreshable
+  access token. Optional overrides are available for scopes if additional Drive
+  permissions are required.
 - Configuration values describing folder IDs, polling intervals, and local
   output paths. A starter configuration can be found in
   [`example.config.json`](example.config.json).
+- An optional Git repository destination. Configure `output.provider` as
+  `"git"`, set `output.directory` to the folder within the repository where
+  Markdown should be written, and define the `output.git` block with repository
+  path, branch, and commit settings.
 - An optional prompt file that provides guidance to the downstream Markdown
   generator. A default prompt lives in [`prompts/default_prompt.txt`](prompts/default_prompt.txt).
+
+### Google Drive OAuth setup
+
+To authorize access to an individual's My Drive, create a Google Cloud project,
+enable the Drive API, and generate OAuth client credentials of type "Desktop
+App." Download the resulting JSON secrets file and point
+`google_drive.oauth_client_secrets_file` at its location. On the first run the
+processor will open a local webserver and browser window to complete the OAuth
+consent flow. After you approve the requested scopes (the default is the
+read-only Drive scope), the connector saves the resulting refreshable token to
+`google_drive.oauth_token_file`. Subsequent runs reuse and transparently refresh
+the token so you do not need to reauthorize.
 
 ## Running the Processor
 

--- a/cloud_monitor_pdf2md/output.py
+++ b/cloud_monitor_pdf2md/output.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 from pathlib import Path
 
 from .connectors.base import CloudDocument
@@ -27,4 +28,111 @@ class MarkdownOutputHandler:
         return safe or "document"
 
 
-__all__ = ["MarkdownOutputHandler"]
+class GitMarkdownOutputHandler(MarkdownOutputHandler):
+    """Persist Markdown files inside a Git repository and commit the changes."""
+
+    def __init__(
+        self,
+        repository_path: str | Path,
+        directory: str | Path,
+        *,
+        branch: str = "main",
+        remote: str = "origin",
+        commit_message_template: str = "Add {document_name}",
+        push: bool = False,
+    ) -> None:
+        self.repository_path = Path(repository_path).expanduser().resolve()
+        if not self.repository_path.exists():
+            raise FileNotFoundError(
+                f"Git repository path does not exist: {self.repository_path}"
+            )
+        self._verify_repository()
+        self.branch = branch
+        self.remote = remote
+        self.commit_message_template = commit_message_template
+        self.push = push
+
+        self._ensure_branch()
+
+        resolved_directory = Path(directory)
+        if not resolved_directory.is_absolute():
+            resolved_directory = (self.repository_path / resolved_directory).resolve()
+        else:
+            resolved_directory = resolved_directory.expanduser().resolve()
+
+        try:
+            resolved_directory.relative_to(self.repository_path)
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(
+                "The output directory must reside within the Git repository"
+            ) from exc
+
+        super().__init__(resolved_directory)
+
+    def write(self, document: CloudDocument, markdown: str) -> Path:
+        output_path = super().write(document, markdown)
+        relative_path = output_path.relative_to(self.repository_path)
+        self._run_git("add", str(relative_path))
+
+        if not self._has_staged_changes(relative_path):
+            # Revert the staged file to keep the index clean when nothing changed.
+            self._run_git("reset", "HEAD", "--", str(relative_path))
+            return output_path
+
+        commit_message = self.commit_message_template.format(
+            document_name=document.name,
+            document_identifier=document.identifier,
+        )
+        self._run_git("commit", "-m", commit_message)
+        if self.push:
+            self._run_git("push", self.remote, self.branch)
+        return output_path
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _verify_repository(self) -> None:
+        result = self._run_git("rev-parse", "--is-inside-work-tree", check=False)
+        if result.returncode != 0 or result.stdout.strip() != "true":
+            raise ValueError(f"Path is not a Git repository: {self.repository_path}")
+
+    def _ensure_branch(self) -> None:
+        current = (
+            self._run_git("rev-parse", "--abbrev-ref", "HEAD", check=False)
+            .stdout.strip()
+        )
+        if current == self.branch:
+            return
+        checkout = self._run_git("checkout", self.branch, check=False)
+        if checkout.returncode != 0:
+            self._run_git("checkout", "-b", self.branch)
+
+    def _has_staged_changes(self, relative_path: Path) -> bool:
+        result = self._run_git(
+            "diff",
+            "--cached",
+            "--quiet",
+            "--",
+            str(relative_path),
+            check=False,
+        )
+        if result.returncode not in (0, 1):
+            raise RuntimeError(result.stderr.strip())
+        return result.returncode == 1
+
+    def _run_git(
+        self,
+        *args: str,
+        check: bool = True,
+        capture_output: bool = True,
+    ) -> subprocess.CompletedProcess[str]:
+        completed = subprocess.run(
+            ["git", "-C", str(self.repository_path), *args],
+            check=check,
+            capture_output=capture_output,
+            text=True,
+        )
+        return completed
+
+
+__all__ = ["GitMarkdownOutputHandler", "MarkdownOutputHandler"]

--- a/example.config.json
+++ b/example.config.json
@@ -1,6 +1,6 @@
 {
-  "provider": "local",
-  "poll_interval": 60,
+  "provider": "google_drive",
+  "poll_interval": 300,
   "output": {
     "directory": "./output"
   },
@@ -10,7 +10,12 @@
   "llm": {
     "provider": "simple"
   },
-  "local": {
-    "path": "./sample_pdfs"
+  "google_drive": {
+    "folder_id": "YOUR_FOLDER_ID",
+    "oauth_client_secrets_file": "./credentials/client_secret.json",
+    "oauth_token_file": "./credentials/token.json",
+    "scopes": [
+      "https://www.googleapis.com/auth/drive.readonly"
+    ]
   }
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_config_google_drive.py
+++ b/tests/test_config_google_drive.py
@@ -1,0 +1,75 @@
+"""Configuration validation for the Google Drive connector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cloud_monitor_pdf2md.config import AppConfig
+
+
+def _base_config_dict(tmp_path: Path) -> dict:
+    return {
+        "provider": "google_drive",
+        "poll_interval": 10,
+        "output": {"directory": str(tmp_path / "output")},
+        "state": {"path": str(tmp_path / "state.json")},
+        "llm": {"provider": "simple"},
+    }
+
+
+def test_google_drive_config_requires_oauth_paths(tmp_path: Path) -> None:
+    config_data = _base_config_dict(tmp_path)
+    config_data["google_drive"] = {"folder_id": "folder-123"}
+
+    with pytest.raises(ValueError):
+        AppConfig.from_dict(config_data)
+
+
+def test_google_drive_config_resolves_oauth_paths(tmp_path: Path) -> None:
+    config_data = _base_config_dict(tmp_path)
+    client_secrets = tmp_path / "client.json"
+    client_secrets.write_text("{}", encoding="utf-8")
+    token_file = tmp_path / "token.json"
+
+    config_data["google_drive"] = {
+        "folder_id": "folder-abc",
+        "oauth_client_secrets_file": str(client_secrets),
+        "oauth_token_file": str(token_file),
+    }
+
+    app_config = AppConfig.from_dict(config_data)
+
+    assert app_config.google_drive is not None
+    assert app_config.google_drive.folder_id == "folder-abc"
+    assert app_config.google_drive.oauth_client_secrets_file == client_secrets.resolve()
+    assert app_config.google_drive.oauth_token_file == token_file.resolve()
+    assert app_config.google_drive.scopes == (
+        "https://www.googleapis.com/auth/drive.readonly",
+    )
+
+
+def test_google_drive_config_allows_scope_overrides(tmp_path: Path) -> None:
+    config_data = _base_config_dict(tmp_path)
+    client_secrets = tmp_path / "client.json"
+    client_secrets.write_text("{}", encoding="utf-8")
+    token_file = tmp_path / "token.json"
+
+    config_data["google_drive"] = {
+        "folder_id": "folder-scoped",
+        "oauth_client_secrets_file": str(client_secrets),
+        "oauth_token_file": str(token_file),
+        "scopes": [
+            "https://www.googleapis.com/auth/drive.metadata.readonly",
+            "https://www.googleapis.com/auth/drive.readonly",
+        ],
+    }
+
+    app_config = AppConfig.from_dict(config_data)
+
+    assert app_config.google_drive is not None
+    assert app_config.google_drive.scopes == (
+        "https://www.googleapis.com/auth/drive.metadata.readonly",
+        "https://www.googleapis.com/auth/drive.readonly",
+    )

--- a/tests/test_git_output.py
+++ b/tests/test_git_output.py
@@ -1,0 +1,83 @@
+"""Tests for the Git-backed Markdown output handler."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from cloud_monitor_pdf2md.connectors.base import CloudDocument
+from cloud_monitor_pdf2md.output import GitMarkdownOutputHandler
+
+
+def _init_git_repository(path: Path) -> None:
+    result = subprocess.run(
+        ["git", "init", "--initial-branch", "main"],
+        cwd=path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        subprocess.run(["git", "init"], cwd=path, check=True)
+        subprocess.run(["git", "checkout", "-b", "main"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "tests@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Tests"], cwd=path, check=True)
+
+
+def _git_output(*args: str, cwd: Path) -> str:
+    result = subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+    return result.stdout.strip()
+
+
+def test_git_output_handler_commits_changes(tmp_path: Path) -> None:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    _init_git_repository(repository)
+
+    handler = GitMarkdownOutputHandler(
+        repository_path=repository,
+        directory="notes",
+        branch="main",
+        commit_message_template="Add {document_name}",
+        push=False,
+    )
+
+    document = CloudDocument(identifier="doc-123", name="Project Plan")
+    output_path = handler.write(document, "# Project Plan\n")
+
+    assert output_path.exists()
+    assert output_path.relative_to(repository) == Path("notes/Project-Plan.md")
+
+    last_commit_message = _git_output("log", "-1", "--pretty=%s", cwd=repository)
+    assert last_commit_message == "Add Project Plan"
+
+    rev_count = _git_output("rev-list", "--count", "HEAD", cwd=repository)
+    assert rev_count == "1"
+
+    # Writing new content should produce another commit.
+    handler.write(CloudDocument(identifier="doc-456", name="Status Update"), "# Update\n")
+    rev_count_after = _git_output("rev-list", "--count", "HEAD", cwd=repository)
+    assert rev_count_after == "2"
+
+
+def test_git_output_handler_skips_empty_commits(tmp_path: Path) -> None:
+    repository = tmp_path / "repo"
+    repository.mkdir()
+    _init_git_repository(repository)
+
+    handler = GitMarkdownOutputHandler(
+        repository_path=repository,
+        directory="notes",
+        branch="main",
+        commit_message_template="Add {document_name}",
+        push=False,
+    )
+
+    document = CloudDocument(identifier="doc-1", name="Notebook")
+    handler.write(document, "# Notes\n")
+    initial_rev_count = _git_output("rev-list", "--count", "HEAD", cwd=repository)
+
+    handler.write(document, "# Notes\n")
+    rev_count_after = _git_output("rev-list", "--count", "HEAD", cwd=repository)
+
+    assert initial_rev_count == rev_count_after

--- a/tests/test_google_drive_connector.py
+++ b/tests/test_google_drive_connector.py
@@ -1,0 +1,128 @@
+"""Tests for the Google Drive connector implementation."""
+
+from __future__ import annotations
+
+import sys
+import types
+from datetime import datetime, timezone
+
+import pytest
+
+from cloud_monitor_pdf2md.connectors.base import CloudDocument
+from cloud_monitor_pdf2md.connectors.google_drive import GoogleDriveConnector
+
+
+class _FakeRequest:
+    def __init__(self, response: dict):
+        self._response = response
+
+    def execute(self) -> dict:
+        return self._response
+
+
+class _FakeFilesResource:
+    def __init__(self, list_responses: list[dict], media_payloads: dict[str, bytes]):
+        self._list_responses = list_responses
+        self._media_payloads = media_payloads
+        self.list_calls: list[dict] = []
+        self._list_index = 0
+        self.get_media_calls: list[str] = []
+
+    def list(self, **kwargs):  # pragma: no cover - thin wrapper
+        response = self._list_responses[self._list_index]
+        self._list_index += 1
+        self.list_calls.append(kwargs)
+        return _FakeRequest(response)
+
+    def get_media(self, fileId: str):  # noqa: N803 - API parity
+        self.get_media_calls.append(fileId)
+        return types.SimpleNamespace(content=self._media_payloads[fileId])
+
+
+class _FakeDriveService:
+    def __init__(self, files_resource: _FakeFilesResource):
+        self._files_resource = files_resource
+
+    def files(self):  # pragma: no cover - API adapter
+        return self._files_resource
+
+
+@pytest.fixture()
+def fake_drive_service() -> tuple[GoogleDriveConnector, _FakeFilesResource]:
+    list_responses = [
+        {
+            "files": [
+                {
+                    "id": "doc-1",
+                    "name": "Quarterly Report",
+                    "modifiedTime": "2024-01-15T12:34:56Z",
+                    "webViewLink": "https://drive.example/doc-1",
+                }
+            ],
+            "nextPageToken": "token-1",
+        },
+        {
+            "files": [
+                {
+                    "id": "doc-2",
+                    "name": "Roadmap",
+                    "modifiedTime": "2024-02-01T08:00:00Z",
+                    "webViewLink": "https://drive.example/doc-2",
+                }
+            ],
+        },
+    ]
+    media_payloads = {
+        "doc-1": b"PDF data 1",
+        "doc-2": b"PDF data 2",
+    }
+    files_resource = _FakeFilesResource(list_responses, media_payloads)
+    connector = GoogleDriveConnector(
+        service=_FakeDriveService(files_resource),
+        folder_id="folder-123",
+        page_size=10,
+    )
+    return connector, files_resource
+
+
+def test_list_pdfs_collects_paginated_results(fake_drive_service: tuple[GoogleDriveConnector, _FakeFilesResource]):
+    connector, files_resource = fake_drive_service
+    documents = list(connector.list_pdfs())
+
+    assert [doc.identifier for doc in documents] == ["doc-1", "doc-2"]
+    assert documents[0].name == "Quarterly Report"
+    assert documents[0].modified_at == datetime(2024, 1, 15, 12, 34, 56, tzinfo=timezone.utc)
+
+    assert len(files_resource.list_calls) == 2
+    first_call = files_resource.list_calls[0]
+    assert first_call["q"].startswith("'folder-123' in parents")
+    assert first_call["pageSize"] == 10
+
+
+def test_download_pdf_streams_content(monkeypatch: pytest.MonkeyPatch, fake_drive_service: tuple[GoogleDriveConnector, _FakeFilesResource]):
+    connector, files_resource = fake_drive_service
+
+    class _FakeDownloader:
+        def __init__(self, buffer, request):
+            self._buffer = buffer
+            self._request = request
+            self._finished = False
+
+        def next_chunk(self):
+            if self._finished:
+                return None, True
+            self._buffer.write(self._request.content)
+            self._finished = True
+            return None, True
+
+    google_module = types.ModuleType("googleapiclient")
+    http_module = types.ModuleType("googleapiclient.http")
+    http_module.MediaIoBaseDownload = _FakeDownloader
+    monkeypatch.setitem(sys.modules, "googleapiclient", google_module)
+    monkeypatch.setitem(sys.modules, "googleapiclient.http", http_module)
+
+    document = CloudDocument(identifier="doc-2", name="Roadmap")
+    payload = connector.download_pdf(document)
+
+    assert payload == b"PDF data 2"
+    assert files_resource.get_media_calls == ["doc-2"]

--- a/tests/test_processor_google_drive.py
+++ b/tests/test_processor_google_drive.py
@@ -1,0 +1,295 @@
+"""Tests for constructing the Google Drive connector."""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from cloud_monitor_pdf2md.config import AppConfig
+from cloud_monitor_pdf2md.connectors.google_drive import GoogleDriveConnector
+from cloud_monitor_pdf2md.processor import build_connector
+
+
+def _base_app_config(tmp_path: Path) -> dict:
+    return {
+        "provider": "google_drive",
+        "poll_interval": 30,
+        "output": {"directory": str(tmp_path / "output")},
+        "state": {"path": str(tmp_path / "state.json")},
+        "llm": {"provider": "simple"},
+    }
+
+
+def _install_oauth_modules(
+    monkeypatch: pytest.MonkeyPatch,
+    credentials_cls: type,
+    flow_cls: type,
+    build_func,
+) -> None:
+    google_module = types.ModuleType("google")
+    google_module.__path__ = []
+
+    oauth2_module = types.ModuleType("google.oauth2")
+    oauth2_module.__path__ = []
+    credentials_module = types.ModuleType("google.oauth2.credentials")
+    credentials_module.__path__ = []
+    credentials_module.Credentials = credentials_cls
+    oauth2_module.credentials = credentials_module
+
+    auth_module = types.ModuleType("google.auth")
+    auth_module.__path__ = []
+    transport_module = types.ModuleType("google.auth.transport")
+    transport_module.__path__ = []
+    requests_module = types.ModuleType("google.auth.transport.requests")
+    requests_module.__path__ = []
+
+    class _Request:  # pragma: no cover - placeholder used for typing
+        pass
+
+    requests_module.Request = _Request
+    transport_module.requests = requests_module
+
+    google_auth_oauthlib_module = types.ModuleType("google_auth_oauthlib")
+    google_auth_oauthlib_module.__path__ = []
+    flow_module = types.ModuleType("google_auth_oauthlib.flow")
+    flow_module.__path__ = []
+    flow_module.InstalledAppFlow = flow_cls
+
+    googleapiclient_module = types.ModuleType("googleapiclient")
+    googleapiclient_module.__path__ = []
+    discovery_module = types.ModuleType("googleapiclient.discovery")
+    discovery_module.__path__ = []
+    discovery_module.build = build_func
+
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.oauth2", oauth2_module)
+    monkeypatch.setitem(sys.modules, "google.oauth2.credentials", credentials_module)
+    monkeypatch.setitem(sys.modules, "google.auth", auth_module)
+    monkeypatch.setitem(sys.modules, "google.auth.transport", transport_module)
+    monkeypatch.setitem(sys.modules, "google.auth.transport.requests", requests_module)
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_oauthlib_module)
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_module)
+    monkeypatch.setitem(sys.modules, "googleapiclient", googleapiclient_module)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", discovery_module)
+
+
+def test_build_connector_oauth_uses_existing_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class DummyCredentials:
+        from_file_calls: list[tuple[str, tuple[str, ...]]] = []
+
+        def __init__(
+            self,
+            valid: bool = True,
+            expired: bool = False,
+            refresh_token: str | None = None,
+            token_json: str = "{\"token\": \"cached\"}",
+        ) -> None:
+            self.valid = valid
+            self.expired = expired
+            self.refresh_token = refresh_token
+            self._token_json = token_json
+            self.refresh_invocations = 0
+
+        @classmethod
+        def from_authorized_user_file(cls, filename: str, scopes: list[str]):
+            cls.from_file_calls.append((filename, tuple(scopes)))
+            data = json.loads(Path(filename).read_text(encoding="utf-8"))
+            return cls(
+                valid=data.get("valid", True),
+                expired=data.get("expired", False),
+                refresh_token=data.get("refresh_token"),
+                token_json=data.get("token_json", "{\"token\": \"cached\"}"),
+            )
+
+        def refresh(self, request):  # pragma: no cover - not triggered here
+            self.refresh_invocations += 1
+            self.valid = True
+            self.expired = False
+
+        def to_json(self) -> str:
+            return self._token_json
+
+    class DummyInstalledAppFlow:
+        from_file_calls: list[tuple[str, tuple[str, ...]]] = []
+        run_calls = 0
+
+        @classmethod
+        def from_client_secrets_file(cls, filename: str, scopes: list[str]):
+            cls.from_file_calls.append((filename, tuple(scopes)))
+            return cls()
+
+        def run_local_server(self, port: int = 0):  # pragma: no cover - not triggered here
+            type(self).run_calls += 1
+            return DummyCredentials()
+
+    def fake_build(service_name: str, version: str, credentials):
+        fake_build.calls.append((service_name, version, credentials))
+        return object()
+
+    fake_build.calls = []  # type: ignore[attr-defined]
+
+    _install_oauth_modules(monkeypatch, DummyCredentials, DummyInstalledAppFlow, fake_build)
+
+    client_secrets = tmp_path / "client.json"
+    client_secrets.write_text("{}", encoding="utf-8")
+    token_file = tmp_path / "token.json"
+    token_file.write_text(json.dumps({"valid": True}), encoding="utf-8")
+
+    config_dict = _base_app_config(tmp_path)
+    config_dict["google_drive"] = {
+        "folder_id": "folder-xyz",
+        "oauth_client_secrets_file": str(client_secrets),
+        "oauth_token_file": str(token_file),
+    }
+
+    connector = build_connector(AppConfig.from_dict(config_dict))
+
+    assert isinstance(connector, GoogleDriveConnector)
+    assert DummyCredentials.from_file_calls == [
+        (str(token_file.resolve()), ("https://www.googleapis.com/auth/drive.readonly",)),
+    ]
+    assert DummyInstalledAppFlow.from_file_calls == []
+    assert fake_build.calls[0][2].refresh_invocations == 0
+
+
+def test_build_connector_oauth_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class DummyCredentials:
+        from_file_calls: list[tuple[str, tuple[str, ...]]] = []
+
+        def __init__(
+            self,
+            valid: bool = False,
+            expired: bool = True,
+            refresh_token: str | None = "refresh-token",
+            token_json: str = "{\"token\": \"cached\"}",
+        ) -> None:
+            self.valid = valid
+            self.expired = expired
+            self.refresh_token = refresh_token
+            self._token_json = token_json
+            self.refresh_invocations = 0
+
+        @classmethod
+        def from_authorized_user_file(cls, filename: str, scopes: list[str]):
+            cls.from_file_calls.append((filename, tuple(scopes)))
+            data = json.loads(Path(filename).read_text(encoding="utf-8"))
+            return cls(
+                valid=data.get("valid", False),
+                expired=data.get("expired", True),
+                refresh_token=data.get("refresh_token", "refresh-token"),
+                token_json=data.get("token_json", "{\"token\": \"cached\"}"),
+            )
+
+        def refresh(self, request):
+            self.refresh_invocations += 1
+            self.valid = True
+            self.expired = False
+
+        def to_json(self) -> str:
+            return self._token_json
+
+    class DummyInstalledAppFlow:
+        from_file_calls: list[tuple[str, tuple[str, ...]]] = []
+        run_calls = 0
+
+        @classmethod
+        def from_client_secrets_file(cls, filename: str, scopes: list[str]):  # pragma: no cover - not used
+            cls.from_file_calls.append((filename, tuple(scopes)))
+            return cls()
+
+        def run_local_server(self, port: int = 0):  # pragma: no cover - not used
+            type(self).run_calls += 1
+            return DummyCredentials(valid=True, expired=False)
+
+    def fake_build(service_name: str, version: str, credentials):
+        fake_build.calls.append((service_name, version, credentials))
+        return object()
+
+    fake_build.calls = []  # type: ignore[attr-defined]
+
+    _install_oauth_modules(monkeypatch, DummyCredentials, DummyInstalledAppFlow, fake_build)
+
+    client_secrets = tmp_path / "client.json"
+    client_secrets.write_text("{}", encoding="utf-8")
+    token_file = tmp_path / "token.json"
+    token_file.write_text(
+        json.dumps({"valid": False, "expired": True, "refresh_token": "refresh-token"}),
+        encoding="utf-8",
+    )
+
+    config_dict = _base_app_config(tmp_path)
+    config_dict["google_drive"] = {
+        "folder_id": "folder-refresh",
+        "oauth_client_secrets_file": str(client_secrets),
+        "oauth_token_file": str(token_file),
+    }
+
+    connector = build_connector(AppConfig.from_dict(config_dict))
+
+    assert isinstance(connector, GoogleDriveConnector)
+    assert DummyInstalledAppFlow.from_file_calls == []
+    assert fake_build.calls[0][2].refresh_invocations == 1
+    assert token_file.read_text(encoding="utf-8") == "{\"token\": \"cached\"}"
+
+
+def test_build_connector_oauth_runs_flow_when_missing_token(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    class DummyCredentials:
+        def __init__(self, token_json: str = "{\"token\": \"flow\"}") -> None:
+            self.valid = True
+            self.expired = False
+            self.refresh_token = None
+            self._token_json = token_json
+            self.refresh_invocations = 0
+
+        def refresh(self, request):  # pragma: no cover - not used
+            raise AssertionError("refresh should not be called in flow path")
+
+        def to_json(self) -> str:
+            return self._token_json
+
+    class DummyInstalledAppFlow:
+        from_file_calls: list[tuple[str, tuple[str, ...]]] = []
+        run_calls = 0
+
+        @classmethod
+        def from_client_secrets_file(cls, filename: str, scopes: list[str]):
+            cls.from_file_calls.append((filename, tuple(scopes)))
+            return cls()
+
+        def run_local_server(self, port: int = 0):
+            type(self).run_calls += 1
+            return DummyCredentials()
+
+    def fake_build(service_name: str, version: str, credentials):
+        fake_build.calls.append((service_name, version, credentials))
+        return object()
+
+    fake_build.calls = []  # type: ignore[attr-defined]
+
+    _install_oauth_modules(monkeypatch, DummyCredentials, DummyInstalledAppFlow, fake_build)
+
+    client_secrets = tmp_path / "client.json"
+    client_secrets.write_text("{}", encoding="utf-8")
+    token_file = tmp_path / "token.json"
+
+    config_dict = _base_app_config(tmp_path)
+    config_dict["google_drive"] = {
+        "folder_id": "folder-flow",
+        "oauth_client_secrets_file": str(client_secrets),
+        "oauth_token_file": str(token_file),
+    }
+
+    connector = build_connector(AppConfig.from_dict(config_dict))
+
+    assert isinstance(connector, GoogleDriveConnector)
+    assert DummyInstalledAppFlow.from_file_calls == [
+        (str(client_secrets.resolve()), ("https://www.googleapis.com/auth/drive.readonly",)),
+    ]
+    assert DummyInstalledAppFlow.run_calls == 1
+    assert token_file.exists()
+    assert token_file.read_text(encoding="utf-8") == "{\"token\": \"flow\"}"
+


### PR DESCRIPTION
## Summary
- require OAuth client secret and token cache paths in the Google Drive configuration and remove service-account fields
- update the Google Drive bootstrapper to always authenticate with InstalledAppFlow credentials and persist refreshed tokens
- refresh the README, example configuration, and tests to reflect the OAuth-only flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb4e7640a0832f8451f03db54f83ec