### PR TITLE
Add Obsidian vault integration with media handling

### DIFF
--- a/cloud_monitor_pdf2md/processor.py
+++ b/cloud_monitor_pdf2md/processor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from .config import AppConfig
@@ -13,7 +14,11 @@ from .connectors.google_drive import GoogleDriveConnector
 from .connectors.local import LocalFolderConnector
 from .llm.base import LLMClient
 from .llm.simple import SimpleLLMClient
-from .output import GitMarkdownOutputHandler, MarkdownOutputHandler
+from .output import (
+    GitMarkdownOutputHandler,
+    MarkdownOutputHandler,
+    ObsidianVaultOutputHandler,
+)
 from .state import ProcessingState
 
 LOGGER = logging.getLogger("cloud_monitor_pdf2md")
@@ -38,7 +43,9 @@ class PDFProcessor:
             LOGGER.info("Processing %s", document.name)
             pdf_bytes = self.connector.download_pdf(document)
             markdown = self.llm_client.convert_pdf(document, pdf_bytes, prompt=self.prompt)
-            output_path = self.output_handler.write(document, markdown)
+            output_path = self.output_handler.write(
+                document, markdown, pdf_bytes=pdf_bytes
+            )
             LOGGER.info("Wrote Markdown to %s", output_path)
             self.state.mark_processed(document.identifier, name=document.name)
             processed += 1
@@ -102,6 +109,18 @@ def build_llm_client(config: AppConfig) -> LLMClient:
         if config.llm.prompt_path and config.llm.prompt_path.exists():
             prompt_content = config.llm.prompt_path.read_text(encoding="utf-8")
         return SimpleLLMClient(prompt=prompt_content)
+    if config.llm.provider == "gemini":
+        from .llm.gemini import GeminiLLMClient
+
+        prompt_content = None
+        if config.llm.prompt_path and config.llm.prompt_path.exists():
+            prompt_content = config.llm.prompt_path.read_text(encoding="utf-8")
+        return GeminiLLMClient(
+            api_key=config.llm.api_key or "",
+            model=config.llm.model or "",
+            prompt=prompt_content,
+            temperature=config.llm.temperature,
+        )
     raise ValueError(f"Unsupported LLM provider: {config.llm.provider}")
 
 
@@ -116,6 +135,25 @@ def build_output_handler(config: AppConfig) -> MarkdownOutputHandler:
             remote=config.output.git.remote,
             commit_message_template=config.output.git.commit_message_template,
             push=config.output.git.push,
+        )
+    if config.output.provider == "obsidian":
+        if not config.output.obsidian:
+            raise ValueError(
+                "Obsidian output requested but obsidian configuration missing"
+            )
+        asset_directory = config.output.asset_directory or Path("media")
+        return ObsidianVaultOutputHandler(
+            repository_path=config.output.obsidian.repository_path,
+            repository_url=config.output.obsidian.repository_url,
+            directory=config.output.directory,
+            media_directory=asset_directory,
+            branch=config.output.obsidian.branch,
+            remote=config.output.obsidian.remote,
+            commit_message_template=config.output.obsidian.commit_message_template,
+            media_mode=config.output.obsidian.media_mode,
+            private_key_path=config.output.obsidian.private_key_path,
+            known_hosts_path=config.output.obsidian.known_hosts_path,
+            push=config.output.obsidian.push,
         )
     return MarkdownOutputHandler(config.output.directory)
 

--- a/example.config.json
+++ b/example.config.json
@@ -2,7 +2,19 @@
   "provider": "google_drive",
   "poll_interval": 300,
   "output": {
-    "directory": "./output"
+    "provider": "obsidian",
+    "directory": "inbox",
+    "asset_directory": "media",
+    "obsidian": {
+      "repository_path": "~/vaults/company-notes",
+      "repository_url": "git@github.com:your-org/obsidian-vault.git",
+      "branch": "main",
+      "remote": "origin",
+      "private_key_path": "~/.ssh/id_ed25519",
+      "known_hosts_path": "~/.ssh/known_hosts",
+      "media_mode": "pdf",
+      "push": true
+    }
   },
   "state": {
     "path": "./state/processed.json"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [{ name = "Cloud Monitor PDF2MD" }]
 requires-python = ">=3.10"
 dependencies = [
     "pypdf>=4.0.0",
+    "pypdfium2>=4.20.0",
     "google-api-python-client>=2.130.0",
     "google-auth>=2.30.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Core runtime dependencies
 pypdf>=4.0.0
+pypdfium2>=4.20.0
 google-api-python-client>=2.130.0
 google-auth>=2.30.0
 google-auth-oauthlib>=1.2.0


### PR DESCRIPTION
## Summary
- add configuration options for cloning and working with an Obsidian Git vault, including media routing settings
- introduce an Obsidian-specific output handler that stages Markdown plus attachments, supports PDF copy or PNG rendering, and manages SSH setup
- extend processor wiring, documentation, dependencies, and tests to cover the new workflow and media export modes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8fba6f8c832f8b0c3952b41e14cf